### PR TITLE
Initial scaffold with FastAPI and data scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-Creation of repo
+# App Helper Chatbot
+
+A local RAG-based chatbot that answers technical questions in Greek using PDF manuals as context.
+
+## Project Structure
+
+- `app/` – FastAPI application
+- `scripts/` – CLI helpers for preparing and ingesting data
+
+## Quickstart
+
+1. Install dependencies:
+
+   ```bash
+   python3.11 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. Run the API:
+
+   ```bash
+   uvicorn app.rag_api:app --reload
+   ```
+
+3. Ingest your PDFs using the scripts in `scripts/`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"App Helper Chatbot package"

--- a/app/rag_api.py
+++ b/app/rag_api.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="App Helper Chatbot")
+
+
+class Question(BaseModel):
+    question: str
+
+
+@app.post("/chat")
+async def chat(question: Question) -> dict[str, list[str] | str]:
+    """Dummy chat endpoint returning a placeholder response in Greek."""
+    return {
+        "answer": "Δεν βρέθηκε σχετική πληροφορία",
+        "sources": [],
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line-length = 88
+target-version = ['py311']
+
+[tool.ruff]
+line-length = 88
+select = ['E', 'F']
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+langchain
+chromadb
+llama-cpp-python
+sentence-transformers
+pypdf

--- a/scripts/chunk_jsonl.py
+++ b/scripts/chunk_jsonl.py
@@ -1,0 +1,35 @@
+"""Chunk JSONL documents for embedding."""
+import json
+import sys
+from pathlib import Path
+
+
+def chunk_text(text: str, size: int = 500) -> list[str]:
+    words = text.split()
+    chunks = []
+    for i in range(0, len(words), size):
+        chunk = " ".join(words[i : i + size])
+        chunks.append(chunk)
+    return chunks
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("Usage: chunk_jsonl.py <input.jsonl> <output.jsonl>")
+        sys.exit(1)
+
+    input_path = Path(sys.argv[1])
+    out_path = Path(sys.argv[2])
+
+    with input_path.open("r", encoding="utf-8") as f_in, out_path.open(
+        "w", encoding="utf-8"
+    ) as f_out:
+        for line in f_in:
+            text = json.loads(line)["text"]
+            for chunk in chunk_text(text):
+                json.dump({"text": chunk}, f_out, ensure_ascii=False)
+                f_out.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_model.sh
+++ b/scripts/download_model.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Download the GGUF model for local use
+MODEL_URL=${MODEL_URL:-"https://example.com/path/to/meltemi7b.q4km.gguf"}
+MODEL_DIR="models"
+mkdir -p "$MODEL_DIR"
+
+curl -L "$MODEL_URL" -o "$MODEL_DIR/model.gguf"

--- a/scripts/extract_pdf_text.py
+++ b/scripts/extract_pdf_text.py
@@ -1,0 +1,32 @@
+"""Extract text from a PDF file and output to JSONL."""
+import json
+import sys
+from pathlib import Path
+
+from pypdf import PdfReader
+
+
+def extract_text(pdf_path: Path) -> list[str]:
+    reader = PdfReader(str(pdf_path))
+    pages = []
+    for page in reader.pages:
+        pages.append(page.extract_text() or "")
+    return pages
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("Usage: extract_pdf_text.py <input.pdf> <output.jsonl>")
+        sys.exit(1)
+    pdf_path = Path(sys.argv[1])
+    out_path = Path(sys.argv[2])
+
+    texts = extract_text(pdf_path)
+    with out_path.open("w", encoding="utf-8") as f:
+        for text in texts:
+            json.dump({"text": text}, f, ensure_ascii=False)
+            f.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,0 +1,33 @@
+"""Load chunks into ChromaDB."""
+import json
+import sys
+from pathlib import Path
+
+import chromadb
+from sentence_transformers import SentenceTransformer
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: ingest.py <chunks.jsonl>")
+        sys.exit(1)
+
+    input_path = Path(sys.argv[1])
+
+    client = chromadb.Client()
+    collection = client.get_or_create_collection("app-helper")
+    embedder = SentenceTransformer("intfloat/multilingual-e5-large")
+
+    docs = []
+    with input_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            text = json.loads(line)["text"]
+            docs.append(text)
+
+    embeddings = embedder.encode(docs)
+    for i, doc in enumerate(docs):
+        collection.add(documents=[doc], embeddings=[embeddings[i]], ids=[str(i)])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create scaffolding for FastAPI RAG service
- add data preparation scripts
- configure `black` and `ruff`
- add project dependencies and quickstart docs

## Testing
- `black app scripts --line-length 88`
- `ruff app scripts`


------
https://chatgpt.com/codex/tasks/task_e_684d480335cc83328b26fe48e83efccd