### PR TITLE
Secure chat endpoint with API token middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ All answers are in Greek and strictly grounded in the ingested documents.
 
 ## ⚙️ Features
 - FastAPI backend with `/chat` endpoint
+- API token authentication via `X-API-Token` header
 - LangChain-powered `ConversationalRetrievalChain` with memory and contextual reranking
 - Embedding model: `intfloat/multilingual-e5-large`
 - Language model: Meltemi 7B Instruct (GGUF) running via `llama-cpp-python`
@@ -41,10 +42,11 @@ All answers are in Greek and strictly grounded in the ingested documents.
    ```bash
    uvicorn app.rag_api:app --reload
    ```
-4. Query it:
+4. Query it (requires an API token):
    ```bash
    curl -X POST http://localhost:8000/chat \
      -H "Content-Type: application/json" \
+     -H "X-API-Token: <your-token>" \
      -d '{"question":"Πώς κάνω εισαγωγή αιτημάτων μαζικά;"}'
    ```
 
@@ -66,3 +68,4 @@ pip install -r requirements.txt
 - Model file is expected at: `~/models/meltemi7b.q4km.gguf`
 - This repo is offline-ready, designed for air-gapped environments
 - All responses are restricted to PDF context only
+- Set `CHATBOT_API_TOKEN` to control the required API token

--- a/app/rag_api.py
+++ b/app/rag_api.py
@@ -1,7 +1,32 @@
-from fastapi import FastAPI
+"""FastAPI app exposing a simple RAG chatbot endpoint."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
+
+API_TOKEN = os.getenv("CHATBOT_API_TOKEN", "secret-token")
 
 app = FastAPI(title="App Helper Chatbot")
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Middleware enforcing a static API token for the `/chat` endpoint."""
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path == "/chat":
+            token = request.headers.get("X-API-Token")
+            if token != API_TOKEN:
+                raise HTTPException(
+                    status_code=401, detail="Invalid or missing API token"
+                )
+        return await call_next(request)
+
+
+app.add_middleware(AuthMiddleware)
 
 
 class Question(BaseModel):

--- a/scripts/chunk_jsonl.py
+++ b/scripts/chunk_jsonl.py
@@ -1,4 +1,5 @@
 """Chunk JSONL documents for embedding."""
+
 import json
 import sys
 from pathlib import Path
@@ -21,9 +22,10 @@ def main() -> None:
     input_path = Path(sys.argv[1])
     out_path = Path(sys.argv[2])
 
-    with input_path.open("r", encoding="utf-8") as f_in, out_path.open(
-        "w", encoding="utf-8"
-    ) as f_out:
+    with (
+        input_path.open("r", encoding="utf-8") as f_in,
+        out_path.open("w", encoding="utf-8") as f_out,
+    ):
         for line in f_in:
             text = json.loads(line)["text"]
             for chunk in chunk_text(text):

--- a/scripts/extract_pdf_text.py
+++ b/scripts/extract_pdf_text.py
@@ -1,4 +1,5 @@
 """Extract text from a PDF file and output to JSONL."""
+
 import json
 import sys
 from pathlib import Path

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,4 +1,5 @@
 """Load chunks into ChromaDB."""
+
 import json
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary
- add API token middleware enforcing `X-API-Token` header
- update README with authentication instructions
- format scripts with black

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5705d9d88332b755536f1170556f