### PR TITLE
Add logging and error handling to scripts

### DIFF
--- a/scripts/extract_pdf_text.py
+++ b/scripts/extract_pdf_text.py
@@ -1,5 +1,7 @@
 """Extract text from a PDF file and output to JSONL."""
+
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -7,10 +9,21 @@ from pypdf import PdfReader
 
 
 def extract_text(pdf_path: Path) -> list[str]:
-    reader = PdfReader(str(pdf_path))
+    """Return the text of each PDF page."""
+
+    try:
+        reader = PdfReader(str(pdf_path))
+    except Exception as exc:  # pragma: no cover - simple wrapper
+        logging.error("Failed to read PDF %s: %s", pdf_path, exc)
+        raise
+
     pages = []
-    for page in reader.pages:
-        pages.append(page.extract_text() or "")
+    for i, page in enumerate(reader.pages):
+        try:
+            pages.append(page.extract_text() or "")
+        except Exception as exc:  # pragma: no cover - PDF extraction failure
+            logging.error("Failed to extract text from page %s: %s", i, exc)
+            pages.append("")
     return pages
 
 
@@ -21,11 +34,24 @@ def main() -> None:
     pdf_path = Path(sys.argv[1])
     out_path = Path(sys.argv[2])
 
-    texts = extract_text(pdf_path)
-    with out_path.open("w", encoding="utf-8") as f:
-        for text in texts:
-            json.dump({"text": text}, f, ensure_ascii=False)
-            f.write("\n")
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+    logging.info("Extracting text from %s", pdf_path)
+
+    try:
+        texts = extract_text(pdf_path)
+    except Exception:
+        logging.exception("Extraction failed")
+        sys.exit(1)
+
+    logging.info("Writing JSONL to %s", out_path)
+    try:
+        with out_path.open("w", encoding="utf-8") as f:
+            for text in texts:
+                json.dump({"text": text}, f, ensure_ascii=False)
+                f.write("\n")
+    except Exception:
+        logging.exception("Failed to write output")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,5 +1,7 @@
 """Load chunks into ChromaDB."""
+
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -14,19 +16,38 @@ def main() -> None:
 
     input_path = Path(sys.argv[1])
 
-    client = chromadb.Client()
-    collection = client.get_or_create_collection("app-helper")
-    embedder = SentenceTransformer("intfloat/multilingual-e5-large")
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+    logging.info("Loading chunks from %s", input_path)
+
+    try:
+        client = chromadb.Client()
+        collection = client.get_or_create_collection("app-helper")
+        embedder = SentenceTransformer("intfloat/multilingual-e5-large")
+    except Exception:
+        logging.exception("Failed to initialize components")
+        sys.exit(1)
 
     docs = []
-    with input_path.open("r", encoding="utf-8") as f:
-        for line in f:
-            text = json.loads(line)["text"]
-            docs.append(text)
+    try:
+        with input_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    text = json.loads(line)["text"]
+                except Exception as exc:
+                    logging.error("Invalid JSON line: %s", exc)
+                    continue
+                docs.append(text)
+    except Exception:
+        logging.exception("Failed to read chunks")
+        sys.exit(1)
 
-    embeddings = embedder.encode(docs)
-    for i, doc in enumerate(docs):
-        collection.add(documents=[doc], embeddings=[embeddings[i]], ids=[str(i)])
+    try:
+        embeddings = embedder.encode(docs)
+        for i, doc in enumerate(docs):
+            collection.add(documents=[doc], embeddings=[embeddings[i]], ids=[str(i)])
+    except Exception:
+        logging.exception("Failed to store embeddings")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add try/except blocks to ingestion scripts
- log progress and failures using Python's logging module

## Testing
- `black scripts/extract_pdf_text.py scripts/chunk_jsonl.py scripts/ingest.py`
- `ruff check scripts/extract_pdf_text.py scripts/chunk_jsonl.py scripts/ingest.py`
- `python -m compileall -q scripts`


------
https://chatgpt.com/codex/tasks/task_e_684d570ff7d48332b9c8f7df57c32735